### PR TITLE
Configure `hawkeye` to update license headers

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -1,0 +1,31 @@
+amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.2.0#/PklCI.pkl"
+
+local testJobs = jobs.keys.filter((it) -> it.startsWith("test"))
+
+jobs {
+  ["test-license-headers"] {
+    docker {
+      new {
+        image = "ghcr.io/korandoru/hawkeye"
+      }
+    }
+    steps {
+      "checkout"
+      new RunStep {
+        command = "/bin/hawkeye check --fail-if-unknown"
+      }
+    }
+  }
+}
+
+prb {
+  jobs {
+    ...testJobs
+  }
+}
+
+main {
+  jobs {
+    ...testJobs
+  }
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+# Generated from CircleCI.pkl. DO NOT EDIT.
+version: '2.1'
+orbs:
+  pr-approval: apple/pr-approval@0.1.0
+jobs:
+  test-license-headers:
+    steps:
+    - checkout
+    - run:
+        command: /bin/hawkeye check --fail-if-unknown
+    docker:
+    - image: ghcr.io/korandoru/hawkeye
+workflows:
+  prb:
+    jobs:
+    - hold:
+        type: approval
+    - pr-approval/authenticate:
+        context: pkl-pr-approval
+    - test-license-headers:
+        requires:
+        - hold
+    when:
+      matches:
+        value: << pipeline.git.branch >>
+        pattern: ^pull/\d+(/head)?$
+  main:
+    jobs:
+    - test-license-headers
+    when:
+      equal:
+      - main
+      - << pipeline.git.branch >>

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,0 +1,16 @@
+headerPath = "scripts/license-header.txt"
+
+includes = [
+    "*.pkl",
+    "*.tmSnippet",
+]
+
+[git]
+attrs = 'auto'
+ignore = 'auto'
+
+[properties]
+copyrightOwner = "Apple Inc. and the Pkl project authors"
+
+[mapping.XML_STYLE]
+extensions = ["tmSnippet"]

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -2,7 +2,6 @@ headerPath = "scripts/license-header.txt"
 
 includes = [
     "*.pkl",
-    "*.tmSnippet",
 ]
 
 [git]
@@ -11,6 +10,3 @@ ignore = 'auto'
 
 [properties]
 copyrightOwner = "Apple Inc. and the Pkl project authors"
-
-[mapping.XML_STYLE]
-extensions = ["tmSnippet"]

--- a/pkl/index.pkl
+++ b/pkl/index.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkl/pkl.tmLanguage.pkl
+++ b/pkl/pkl.tmLanguage.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkl/snippets.pkl
+++ b/pkl/snippets.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkl/tmLanguage.pkl
+++ b/pkl/tmLanguage.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/license-header.txt
+++ b/scripts/license-header.txt
@@ -1,0 +1,13 @@
+Copyright ©{{ " " }}{%- if attrs.git_file_modified_year != attrs.git_file_created_year -%}{{ attrs.git_file_created_year }}-{{ attrs.git_file_modified_year }}{%- else -%}{{ attrs.git_file_created_year }}{%- endif -%}{{ " " }}{{ props["copyrightOwner"] }}. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Adds configuration to format/check license headers with `hawkeye`.

Additionally, ran the formatter on license headers that needed to be updated.

### Reviewer's note

There's currently no CI configured for this repository, so consider the `.circleci` configuration a placeholder until that's configured.